### PR TITLE
chore: bump pre commit tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,8 @@ repos:
     rev: v0.15.15
     hooks:
       # Ruff Linter
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-check
+        args: [--fix]
         types_or: [python, pyi, jupyter]
       # Ruff Formatter
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -21,7 +21,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: v1.5.6
     hooks:
       - id: forbid-tabs
       - id: remove-tabs
@@ -42,7 +42,7 @@ repos:
           - markdown
           - terraform
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.15.15
     hooks:
       # Ruff Linter
       - id: ruff
@@ -52,18 +52,18 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/PyCQA/bandit
-    rev: "1.8.3"
+    rev: "1.9.4"
     hooks:
       - id: bandit
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.4
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
-Bump pre-commit repo versions
- Replace legacy ruff hook with ruff-check hook